### PR TITLE
fix(renovate): use array for schedule

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,6 +1,6 @@
 {
   "extends": ["config:recommended"],
-  "schedule": "every weekday",
+  "schedule": ["every weekday"],
   "labels": ["dependencies", "{{manager}}"],
   "enabledManagers": [
     "cargo",


### PR DESCRIPTION
The dashboard throws "schedule.some is not a function", which may be undetected by the renovate validator.