### PR TITLE
fix(app): include doctype in html

### DIFF
--- a/srcs/app/index.html
+++ b/srcs/app/index.html
@@ -1,3 +1,4 @@
+<!doctype html>
 <html lang="en">
   <head>
     <meta charset="utf-8" />


### PR DESCRIPTION
This helps the browser identify the document type, which in this case should be HTML 5.